### PR TITLE
商品情報編集機能

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,12 +1,12 @@
 class ProductsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
+  before_action :set_product, only: [:show, :edit, :update]
 
   def index
     @products = Product.order(created_at: :desc)
   end
 
   def show
-    @product = Product.find(params[:id])
   end
 
   def new
@@ -23,22 +23,24 @@ class ProductsController < ApplicationController
   end
 
   def edit
-    @product = Product.find(params[:id])
     unless @product.user == current_user
       redirect_to root_path, alert: '他のユーザーの商品情報を編集することはできません。'
     end
   end
 
   def update
-    @product = Product.find(params[:id])
-  if @product.update(product_params)
-    redirect_to product_path(@product), notice: '商品情報が更新されました。'
-  else
-    render :edit, status: :unprocessable_entity
+    if @product.update(product_params)
+      redirect_to product_path(@product), notice: '商品情報が更新されました。'
+    else
+      render :edit, status: :unprocessable_entity
+    end
   end
-end
 
   private
+
+  def set_product
+    @product = Product.find(params[:id])
+  end
 
   def product_params
     params.require(:product).permit(:product_name, :description_item, :price, :image, :category_id, :condition_id, :shipping_charge_id, :prefecture_id, :shipping_date_id).merge(user_id: current_user.id)

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -22,6 +22,22 @@ class ProductsController < ApplicationController
     end
   end
 
+  def edit
+    @product = Product.find(params[:id])
+    unless @product.user == current_user
+      redirect_to root_path, alert: '他のユーザーの商品情報を編集することはできません。'
+    end
+  end
+
+  def update
+    @product = Product.find(params[:id])
+  if @product.update(product_params)
+    redirect_to product_path(@product), notice: '商品情報が更新されました。'
+  else
+    render :edit, status: :unprocessable_entity
+  end
+end
+
   private
 
   def product_params

--- a/app/views/products/edit.html.erb
+++ b/app/views/products/edit.html.erb
@@ -7,11 +7,8 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with local: true do |f| %>
-
-    <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-    <%# render 'shared/error_messages', model: f.object %>
-    <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
+    <%= form_with model: @product, local: true do |f| %>
+    <%= render 'shared/error_messages', model: f.object %>
 
     <%# 商品画像 %>
     <div class="img-upload">
@@ -23,128 +20,128 @@ app/assets/stylesheets/items/new.css %>
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%= f.file_field :hoge, id:"item-image" %>
+        <%= f.file_field :image, id:"item-image" %>
       </div>
     </div>
     <%# /商品画像 %>
     <%# 商品名と商品説明 %>
-    <div class="new-items">
-      <div class="weight-bold-text">
-        商品名
+<div class="new-items">
+  <div class="weight-bold-text">
+    商品名
+    <span class="indispensable">必須</span>
+  </div>
+  <%= f.text_area :product_name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+  <div class="items-explain">
+    <div class="weight-bold-text">
+      商品の説明
+      <span class="indispensable">必須</span>
+    </div>
+    <%= f.text_area :description_item, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+  </div>
+</div>
+<%# /商品名と商品説明 %>
+
+<%# 商品の詳細 %>
+<div class="items-detail">
+  <div class="weight-bold-text">商品の詳細</div>
+  <div class="form">
+    <div class="weight-bold-text">
+      カテゴリー
+      <span class="indispensable">必須</span>
+    </div>
+    <%= f.collection_select(:category_id,Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
+    <div class="weight-bold-text">
+      商品の状態
+      <span class="indispensable">必須</span>
+    </div>
+    <%= f.collection_select(:condition_id, Condition.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
+  </div>
+</div>
+<%# /商品の詳細 %>
+
+<%# 配送について %>
+<div class="items-detail">
+  <div class="weight-bold-text question-text">
+    <span>配送について</span>
+    <a class="question" href="#">?</a>
+  </div>
+  <div class="form">
+    <div class="weight-bold-text">
+      配送料の負担
+      <span class="indispensable">必須</span>
+    </div>
+    <%= f.collection_select(:shipping_charge_id, ShippingCharge.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+    <div class="weight-bold-text">
+      発送元の地域
+      <span class="indispensable">必須</span>
+    </div>
+    <%= f.collection_select(:prefecture_id, Prefecture.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
+    <div class="weight-bold-text">
+      発送までの日数
+      <span class="indispensable">必須</span>
+    </div>
+    <%= f.collection_select(:shipping_date_id, ShippingDate.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+  </div>
+</div>
+<%# /配送について %>
+
+<%# 販売価格 %>
+<div class="sell-price">
+  <div class="weight-bold-text question-text">
+    <span>販売価格<br>(¥300〜9,999,999)</span>
+    <a class="question" href="#">?</a>
+  </div>
+  <div>
+    <div class="price-content">
+      <div class="price-text">
+        <span>価格</span>
         <span class="indispensable">必須</span>
       </div>
-      <%= f.text_area :hoge, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
-      <div class="items-explain">
-        <div class="weight-bold-text">
-          商品の説明
-          <span class="indispensable">必須</span>
-        </div>
-        <%= f.text_area :hoge, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
-      </div>
+      <span class="sell-yen">¥</span>
+      <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
     </div>
-    <%# /商品名と商品説明 %>
-
-    <%# 商品の詳細 %>
-    <div class="items-detail">
-      <div class="weight-bold-text">商品の詳細</div>
-      <div class="form">
-        <div class="weight-bold-text">
-          カテゴリー
-          <span class="indispensable">必須</span>
-        </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-category"}) %>
-        <div class="weight-bold-text">
-          商品の状態
-          <span class="indispensable">必須</span>
-        </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-sales-status"}) %>
-      </div>
+    <div class="price-content">
+      <span>販売手数料 (10%)</span>
+      <span>
+        <span id='add-tax-price'></span>円
+      </span>
     </div>
-    <%# /商品の詳細 %>
-
-    <%# 配送について %>
-    <div class="items-detail">
-      <div class="weight-bold-text question-text">
-        <span>配送について</span>
-        <a class="question" href="#">?</a>
-      </div>
-      <div class="form">
-        <div class="weight-bold-text">
-          配送料の負担
-          <span class="indispensable">必須</span>
-        </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
-        <div class="weight-bold-text">
-          発送元の地域
-          <span class="indispensable">必須</span>
-        </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-prefecture"}) %>
-        <div class="weight-bold-text">
-          発送までの日数
-          <span class="indispensable">必須</span>
-        </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
-      </div>
+    <div class="price-content">
+      <span>販売利益</span>
+      <span>
+        <span id='profit'></span>円
+      </span>
     </div>
-    <%# /配送について %>
-
-    <%# 販売価格 %>
-    <div class="sell-price">
-      <div class="weight-bold-text question-text">
-        <span>販売価格<br>(¥300〜9,999,999)</span>
-        <a class="question" href="#">?</a>
-      </div>
-      <div>
-        <div class="price-content">
-          <div class="price-text">
-            <span>価格</span>
-            <span class="indispensable">必須</span>
-          </div>
-          <span class="sell-yen">¥</span>
-          <%= f.text_field :hoge, class:"price-input", id:"item-price", placeholder:"例）300" %>
-        </div>
-        <div class="price-content">
-          <span>販売手数料 (10%)</span>
-          <span>
-            <span id='add-tax-price'></span>円
-          </span>
-        </div>
-        <div class="price-content">
-          <span>販売利益</span>
-          <span>
-            <span id='profit'></span>円
-          </span>
-        </div>
-      </div>
-    </div>
-    <%# /販売価格 %>
-
-    <%# 注意書き %>
-    <div class="caution">
-      <p class="sentence">
-        <a href="#">禁止されている出品、</a>
-        <a href="#">行為</a>
-        を必ずご確認ください。
-      </p>
-      <p class="sentence">
-        またブランド品でシリアルナンバー等がある場合はご記載ください。
-        <a href="#">偽ブランドの販売</a>
-        は犯罪であり処罰される可能性があります。
-      </p>
-      <p class="sentence">
-        また、出品をもちまして
-        <a href="#">加盟店規約</a>
-        に同意したことになります。
-      </p>
-    </div>
-    <%# /注意書き %>
-    <%# 下部ボタン %>
-    <div class="sell-btn-contents">
-      <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', "#", class:"back-btn" %>
-    </div>
-    <%# /下部ボタン %>
   </div>
+</div>
+<%# /販売価格 %>
+
+<%# 注意書き %>
+<div class="caution">
+  <p class="sentence">
+    <a href="#">禁止されている出品、</a>
+    <a href="#">行為</a>
+    を必ずご確認ください。
+  </p>
+  <p class="sentence">
+    またブランド品でシリアルナンバー等がある場合はご記載ください。
+    <a href="#">偽ブランドの販売</a>
+    は犯罪であり処罰される可能性があります。
+  </p>
+  <p class="sentence">
+    また、出品をもちまして
+    <a href="#">加盟店規約</a>
+    に同意したことになります。
+  </p>
+</div>
+<%# /注意書き %>
+<%# 下部ボタン %>
+<div class="sell-btn-contents">
+  <%= f.submit "変更する" ,class:"sell-btn" %>
+  <%=link_to 'もどる', product_path, class:"back-btn" %>
+</div>
+<%# /下部ボタン %>
+</div>
   <% end %>
 
   <footer class="items-sell-footer">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,9 @@ Rails.application.routes.draw do
   root to: "products#index"
   
   resources :products do
+    get 'edit', on: :member
+    resources :orders, only: [:create]
+    patch '/', action: :update, on: :member
     #post 'orders', to: 'orders#create'
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,6 @@ Rails.application.routes.draw do
     #get 'edit', on: :member
     #resources :orders, only: [:create]
     patch '/', action: :update, on: :member
-    #post 'orders', to: 'orders#create'
+    #post 'orders', to: 'orders#create'   
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,6 @@ Rails.application.routes.draw do
     #get 'edit', on: :member
     #resources :orders, only: [:create]
     patch '/', action: :update, on: :member
-    #post 'orders', to: 'orders#create'   
+    #post 'orders', to: 'orders#create'
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,8 +3,8 @@ Rails.application.routes.draw do
   root to: "products#index"
   
   resources :products do
-    get 'edit', on: :member
-    resources :orders, only: [:create]
+    #get 'edit', on: :member
+    #resources :orders, only: [:create]
     patch '/', action: :update, on: :member
     #post 'orders', to: 'orders#create'
   end


### PR DESCRIPTION
# What
商品情報編集機能の作成

# Why
商品情報編集機能実装のため


ログイン状態の出品者は、商品情報編集ページに遷移できる動画
https://gyazo.com/cecbe78dca96d6737a9bc7bd2eab1c85

 必要な情報を適切に入力して「更新する」ボタンを押すと、商品の情報を編集できる動画
https://gyazo.com/0ea5c71798072e288b08eb23729fc615

 入力に問題がある状態で「変更する」ボタンが押された場合、情報は保存されず、編集ページに戻りエラーメッセージが表示される動画
https://gyazo.com/926e578b9b0908dcc40f1040d401638f

 何も編集せずに「更新する」ボタンを押しても、画像無しの商品にならない動画
https://gyazo.com/d6147c8bcdf32dc9bd8fb9a94a11fbb8

 ログイン状態の場合でも、URLを直接入力して自身が出品していない商品の商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずトップページに遷移する動画
https://gyazo.com/30529b318d6a9d049dc9f912f6f50d32

ログアウト状態の場合は、URLを直接入力して商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずログインページに遷移する動画
https://gyazo.com/632986c65519b464fae773e00ed22fc4

 商品名やカテゴリーの情報など、すでに登録されている商品情報は商品情報編集画面を開いた時点で表示される動画（商品画像・販売手数料・販売利益に関しては、表示されない状態で良い)
https://gyazo.com/822004bb1533c4830475abf1e5a721cf